### PR TITLE
Add control for playback marker horizontal position

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -1555,6 +1555,11 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("Reset the waveform zoom level to the default value selected in "
                "Preferences -> Waveforms"),
             pGuiMenu);
+    addControl("[Waveform]",
+            "play_marker_position",
+            tr("Playback Marker Position"),
+            tr("Adjust the horizontal position of the playback marker on the waveforms"),
+            pGuiMenu);
 
     pGuiMenu->addSeparator();
 

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -73,6 +73,10 @@ void Tooltips::addStandardTooltips() {
             << tr("Waveform Zoom")
             << QString("%1").arg(resetToDefault);
 
+    add("[Waveform],play_marker_position")
+            << tr("Playback Marker Position")
+            << tr("Adjust the horizontal position of the playback marker on the waveforms.");
+
     add("spinny")
             << tr("Spinning Vinyl")
             << tr("Rotates during playback and shows the position of a track.")

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -421,6 +421,23 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
                     WaveformWidgetRenderer::s_defaultPlayMarkerPosition);
     setPlayMarkerPosition(m_playMarkerPosition);
 
+    // Create control for playback marker position (0.0 = left, 1.0 = right)
+    if (!m_pPlayMarkerPositionCO) {
+        m_pPlayMarkerPositionCO = std::make_unique<ControlPotmeter>(
+                ConfigKey(kWaveformGroup, QStringLiteral("play_marker_position")),
+                0.0,
+                1.0);
+        m_pPlayMarkerPositionCO->set(m_playMarkerPosition);
+        connect(m_pPlayMarkerPositionCO.get(),
+                &ControlObject::valueChanged,
+                this,
+                [this](double value) {
+                    setPlayMarkerPosition(value);
+                });
+    } else {
+        m_pPlayMarkerPositionCO->set(m_playMarkerPosition);
+    }
+
     int untilMarkShowBeats =
             m_config->getValueString(
                             ConfigKey(kWaveformGroup, QStringLiteral("UntilMarkShowBeats")))

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -3,8 +3,10 @@
 #include <QObject>
 #include <QSurfaceFormat>
 #include <QVector>
+#include <memory>
 #include <vector>
 
+#include "control/controlpotmeter.h"
 #include "preferences/usersettings.h"
 #include "skin/legacy/skincontext.h"
 #include "util/performancetimer.h"
@@ -357,4 +359,5 @@ class WaveformWidgetFactory : public QObject,
     double m_actualFrameRate;
     int m_vSyncType;
     double m_playMarkerPosition;
+    std::unique_ptr<ControlPotmeter> m_pPlayMarkerPositionCO;
 };


### PR DESCRIPTION
## Description

Adds a controllable parameter for adjusting the horizontal position of the playback marker/line on waveforms.

## Changes

- Adds [Waveform],PlayMarkerPosition control (range: 0.0 = left, 1.0 = right)
- Implements ControlPotmeter in WaveformWidgetFactory for smooth value adjustment
- Exposes control in controller picker menu for MIDI/HID mapping
- Adds tooltip documentation for the control
- Preserves existing playback marker position functionality

## Technical Implementation

The control is implemented as a global waveform setting that:
- Persists across sessions via configuration
- Updates all active waveform widgets when changed
- Integrates with the existing playback marker rendering system
- Follows Mixxx control object patterns

## Testing

- [x] Code compiles successfully
- [ ] Manual testing with MIDI controller
- [ ] UI preferences slider works correctly
- [ ] Position persists across application restarts

## Related Issue

Fixes #14288
